### PR TITLE
Add tracking of the sdo dictionary upload progress

### DIFF
--- a/include/ecrt.h
+++ b/include/ecrt.h
@@ -384,6 +384,7 @@ typedef struct {
     } ports[EC_MAX_PORTS]; /**< Port information. */
     uint8_t al_state; /**< Current state of the slave. */
     uint8_t error_flag; /**< Error flag for that slave. */
+    uint8_t sdo_dictionary_fetched; /**< Dictionary status 1=fetching, 2=fetched. */
     uint8_t sync_count; /**< Number of sync managers. */
     uint16_t sdo_count; /**< Number of SDOs. */
     char name[EC_MAX_STRING_LENGTH]; /**< Name of the slave. */

--- a/lib/master.c
+++ b/lib/master.c
@@ -285,6 +285,7 @@ int ecrt_master_get_slave(ec_master_t *master, uint16_t slave_position,
     }
     slave_info->al_state = data.al_state;
     slave_info->error_flag = data.error_flag;
+    slave_info->sdo_dictionary_fetched = data.sdo_dictionary_fetched;
     slave_info->sync_count = data.sync_count;
     slave_info->sdo_count = data.sdo_count;
     strncpy(slave_info->name, data.name, EC_MAX_STRING_LENGTH);

--- a/master/fsm_coe.c
+++ b/master/fsm_coe.c
@@ -1200,6 +1200,7 @@ void ec_fsm_coe_dict_entry_response(
             fsm->sdo->index, fsm->subindex);
 #endif
     }
+    slave->sdo_dictionary_fetched = 2;
 
     fsm->state = ec_fsm_coe_end;
 }

--- a/master/ioctl.h
+++ b/master/ioctl.h
@@ -246,6 +246,7 @@ typedef struct {
     uint32_t transmission_delay;
     uint8_t al_state;
     uint8_t error_flag;
+    uint8_t sdo_dictionary_fetched;
     uint8_t sync_count;
     uint16_t sdo_count;
     uint32_t sii_nwords;

--- a/master/slave.h
+++ b/master/slave.h
@@ -245,7 +245,7 @@ struct ec_slave
     ec_sii_t sii; /**< Extracted SII data. */
 
     struct list_head sdo_dictionary; /**< SDO dictionary list */
-    uint8_t sdo_dictionary_fetched; /**< Dictionary has been fetched. */
+    uint8_t sdo_dictionary_fetched; /**< 1=Dictionary fetching, 2=Dictionary fetched. */
     unsigned long jiffies_preop; /**< Time, the slave went to PREOP. */
 
     struct list_head sdo_requests; /**< SDO access requests. */


### PR DESCRIPTION
The long delay at startup is due to waiting for the SDO dictionary to be uploaded from the slave. This change allows the brain to monitor progress and not hang while waiting for the upload to complete.