### PR TITLE
Named pdo entry

### DIFF
--- a/include/ecrt.h
+++ b/include/ecrt.h
@@ -470,6 +470,7 @@ typedef struct {
     ec_pdo_entry_info_t *entries; /**< Array of PDO entries to map. Can either
                                     be \a NULL, or must contain at
                                     least \a n_entries values. */
+    char name[EC_MAX_STRING_LENGTH];
 } ec_pdo_info_t;
 
 /*****************************************************************************/

--- a/include/ecrt.h
+++ b/include/ecrt.h
@@ -450,6 +450,7 @@ typedef struct {
     uint16_t index; /**< PDO entry index. */
     uint8_t subindex; /**< PDO entry subindex. */
     uint8_t bit_length; /**< Size of the PDO entry in bit. */
+    char name[EC_MAX_STRING_LENGTH];
 } ec_pdo_entry_info_t;
 
 /*****************************************************************************/

--- a/lib/master.c
+++ b/lib/master.c
@@ -352,6 +352,7 @@ int ecrt_master_get_pdo(ec_master_t *master, uint16_t slave_position,
     pdo->index = data.index;
     pdo->n_entries = data.entry_count;
     pdo->entries = NULL;
+    memmove(pdo->name, data.name, EC_IOCTL_STRING_SIZE);
 
     return 0;
 }

--- a/lib/master.c
+++ b/lib/master.c
@@ -352,7 +352,7 @@ int ecrt_master_get_pdo(ec_master_t *master, uint16_t slave_position,
     pdo->index = data.index;
     pdo->n_entries = data.entry_count;
     pdo->entries = NULL;
-    memmove(pdo->name, data.name, EC_IOCTL_STRING_SIZE);
+    memmove(pdo->name, data.name, EC_MAX_STRING_LENGTH);
 
     return 0;
 }
@@ -385,7 +385,7 @@ int ecrt_master_get_pdo_entry(ec_master_t *master, uint16_t slave_position,
     entry->index = data.index;
     entry->subindex = data.subindex;
     entry->bit_length = data.bit_length;
-    memmove(entry->name, data.name, EC_IOCTL_STRING_SIZE);
+    memmove(entry->name, data.name, EC_MAX_STRING_LENGTH);
 
     return 0;
 }

--- a/lib/master.c
+++ b/lib/master.c
@@ -384,6 +384,7 @@ int ecrt_master_get_pdo_entry(ec_master_t *master, uint16_t slave_position,
     entry->index = data.index;
     entry->subindex = data.subindex;
     entry->bit_length = data.bit_length;
+    memmove(entry->name, data.name, EC_IOCTL_STRING_SIZE);
 
     return 0;
 }


### PR DESCRIPTION
For devices not implementing an object dictionary the name field is taken from the pdo and pdo entry instead. Will be tagged with `v1.5.2-mb-1` when merged.